### PR TITLE
`strip` built executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,11 @@ data.h:
 
 playback: playback.c data.h
 	gcc $(CFLAGS) -o playback playback.c
+	strip $(@)
 
 playback.exe: playback.c data.h
 	i686-w64-mingw32-gcc $(CFLAGS) -o playback.exe playback.c
+	i686-w64-mingw32-strip $(@)
 
 clean:
 	rm -f data


### PR DESCRIPTION
After building, strip the executable (both `playback` and
`playback.exe`) to reduce the size.

For a test video, I have the following size reduction:

* `playback`:      83,000 -> 82,600     (-400)
* `playback.exe`: 286,957 -> 84,992 (-201,965)